### PR TITLE
Fixed!

### DIFF
--- a/src/AssetLoader.cs
+++ b/src/AssetLoader.cs
@@ -93,7 +93,8 @@ namespace BooksAndFractals
             stream.Read(bytes);
             Il2CppAssetBundle bundle = Il2CppAssetBundleManager.LoadFromMemory(bytes);
 
-            loadedBundles.Add(bundlePath, bundle);
+            string bundleName = Path.GetFileNameWithoutExtension(bundlePath);
+            loadedBundles.Add(bundleName, bundle);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixed the damn bug where you couldn't load assets once the embedded bundle was preloaded in memory, that was because the bundle name wasn't properly defined in the dictionary.